### PR TITLE
Change group for chown command

### DIFF
--- a/uv4l-socket.sh
+++ b/uv4l-socket.sh
@@ -1,3 +1,3 @@
 sudo systemctl stop raspidisp_server.service
 sudo systemctl disable raspidisp_server.service
-sudo chown pi: $1
+sudo chown pi:pi $1


### PR DESCRIPTION
When running setup.py install chown showed issue because group was not present.